### PR TITLE
Fix issue #4 - don't return null properties

### DIFF
--- a/src/NetatmoProxy/NetatmoProxy/Model/Widget.cs
+++ b/src/NetatmoProxy/NetatmoProxy/Model/Widget.cs
@@ -1,15 +1,23 @@
-﻿namespace NetatmoProxy.Model
+﻿using System.Text.Json.Serialization;
+
+namespace NetatmoProxy.Model
 {
     public class Widget
     {
         public string Type { get; set; }
         public string Description { get; set; }
         public string Value { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string Trend { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string MinValue { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string MaxValue { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string MinTime { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string MaxTime { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public int? BatteryLevel { get; set; }
     }
 }


### PR DESCRIPTION
- For low memory devices the json reponse should not waste memory by containing properties with null value.
![image](https://user-images.githubusercontent.com/791721/211112440-8d215a71-e65a-4828-94c7-235881247113.png)
