### PR TITLE
Issue #14 - Add OutTemp property to humidity widget

### DIFF
--- a/src/NetatmoProxy/NetatmoProxy.Core/Model/Widget.cs
+++ b/src/NetatmoProxy/NetatmoProxy.Core/Model/Widget.cs
@@ -8,6 +8,8 @@ namespace NetatmoProxy.Model
         public string Description { get; set; }
         public string Value { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public decimal? OutTemp { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string Trend { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string MinValue { get; set; }

--- a/src/NetatmoProxy/NetatmoProxy/Controllers/DisplayController.cs
+++ b/src/NetatmoProxy/NetatmoProxy/Controllers/DisplayController.cs
@@ -60,6 +60,7 @@ namespace NetatmoProxy.Controllers
                     Type = "humidity",
                     Description = name,
                     Value = data.Humidity.ToString(),
+                    OutTemp = data.Temperature,
                     BatteryLevel = batteryPercent,
                     SunOrMoon = sunOrMoon
                 };


### PR DESCRIPTION
Fixes issue #14 
- Add property `OutTemp` to `Widget`
- Add value of outdoor temperature to humidity widget as a decimal value