### PR TITLE
Issue #20 - Include configured modules as display widgets

### DIFF
--- a/src/NetatmoProxy/NetatmoProxy.Core/Configuration/NetatmoApiConfig.cs
+++ b/src/NetatmoProxy/NetatmoProxy.Core/Configuration/NetatmoApiConfig.cs
@@ -3,5 +3,6 @@
     public class NetatmoApiConfig
     {
         public string BaseUri { get; set; }
+        public string[] Modules { get; set; }
     }
 }

--- a/src/NetatmoProxy/NetatmoProxy/Program.cs
+++ b/src/NetatmoProxy/NetatmoProxy/Program.cs
@@ -54,9 +54,16 @@ namespace NetatmoProxy
             });
             var netatmoApiConfig = new NetatmoApiConfig();
             Configuration.Bind("NetatmoApi", netatmoApiConfig);
+            builder.Services.AddSingleton<NetatmoApiConfig>(netatmoApiConfig);
             builder.Services.AddSingleton<INetatmoApiService>((sp) =>
             {
-                return new NetatmoApiRestService(netatmoApiConfig, sp.GetService<ILogger<NetatmoApiRestService>>(), sp.GetService<IAccessTokenService>(), HttpClientFactory.Create(), sp.GetService<IMemoryCache>());
+                return new NetatmoApiRestService(
+                    config: sp.GetService<NetatmoApiConfig>(),
+                    logger: sp.GetService<ILogger<NetatmoApiRestService>>(),
+                    accessTokenService: sp.GetService<IAccessTokenService>(), 
+                    httpClient: HttpClientFactory.Create(),
+                    memCache: sp.GetService<IMemoryCache>()
+                    );
             });
 
             builder.Services.AddControllers();

--- a/src/NetatmoProxy/NetatmoProxy/appsettings.json
+++ b/src/NetatmoProxy/NetatmoProxy/appsettings.json
@@ -13,13 +13,15 @@
   "AllowedHosts": "*",
   "NetatmoApi": {
     "Auth": {
+      "BaseUri": "",
       "GrantType": "password",
       "ClientId": "<your-application-id>",
       "ClientSecret": "<your-application-secret>",
       "Username": "<user>",
       "Password": "<password>"
     },
-    "BaseUri": ""
+    "BaseUri": "",
+    "Modules": [ ]
   },
   "DayNightService": {
     "Type": "MetSunriseApi",


### PR DESCRIPTION
Partly fix for issue #20 

- Add Modules property to NetatmoApi configuration to decide which modules to include when creating display widgets
- Only include modules with dashboard data. If a module is unreachable for a period, it must be excluded from the widgets until it's back.