### PR TITLE
Issue #24 - Add battery indicator for all modules on humidy widget

### DIFF
--- a/src/NetatmoProxy/NetatmoProxy.Core/Model/BatteryIndicator.cs
+++ b/src/NetatmoProxy/NetatmoProxy.Core/Model/BatteryIndicator.cs
@@ -1,0 +1,8 @@
+﻿namespace NetatmoProxy.Model
+{
+    public class BatteryIndicator
+    {
+        public string ModuleName { get; set; }
+        public int BatteryLevel { get; set; }
+    }
+}

--- a/src/NetatmoProxy/NetatmoProxy.Core/Model/Widget.cs
+++ b/src/NetatmoProxy/NetatmoProxy.Core/Model/Widget.cs
@@ -23,9 +23,11 @@ namespace NetatmoProxy.Model
         public int? BatteryLevel { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string SunOrMoon { get; set; }
-        [JsonIgnore(Condition =JsonIgnoreCondition.WhenWritingNull)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string Angle { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string MaxAngle { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public BatteryIndicator[] BatteryIndicators { get; set; }
     }
 }

--- a/src/NetatmoProxy/NetatmoProxy/Controllers/DisplayController.cs
+++ b/src/NetatmoProxy/NetatmoProxy/Controllers/DisplayController.cs
@@ -30,6 +30,7 @@ namespace NetatmoProxy.Controllers
             IEnumerable<Device> indoorModules = stationData?.Body?.Devices;
             var outdoorTemperatureModules = new List<Module>();
             var outdoorWindModules = new List<Module>();
+            var batteryIndicators = new List<BatteryIndicator>();
 
             foreach (var indoorModule in indoorModules)
             {
@@ -45,6 +46,14 @@ namespace NetatmoProxy.Controllers
                     && m.DataType.Contains("Wind") && m.DashboardData != null
                     select m
                     );
+                batteryIndicators.AddRange(
+                    from m in indoorModule.Modules
+                    where _config.Modules.Contains(m.ModuleName, StringComparer.InvariantCultureIgnoreCase)
+                    select new BatteryIndicator
+                    {
+                        ModuleName = m.ModuleName,
+                        BatteryLevel = m.BatteryPercent
+                    });
             }
 
             // Exclude indoor modules not configured for display
@@ -94,7 +103,8 @@ namespace NetatmoProxy.Controllers
                     Value = data.Humidity.ToString(),
                     OutTemp = data.Temperature,
                     BatteryLevel = batteryPercent,
-                    SunOrMoon = sunOrMoon
+                    SunOrMoon = sunOrMoon,
+                    BatteryIndicators = batteryIndicators.ToArray()
                 };
             }
 


### PR DESCRIPTION
Fixes issue #24 
- A new property contains an array of battery indicator for all modules and is used on the humidity widget