### PR TITLE
Fix issue #31 - add prometheus exporter

### DIFF
--- a/src/NetatmoProxy/NetatmoProxy.Services/NetatmoProxy.Services.csproj
+++ b/src/NetatmoProxy/NetatmoProxy.Services/NetatmoProxy.Services.csproj
@@ -8,7 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+    <PackageReference Include="prometheus-net" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NetatmoProxy/NetatmoProxy.Services/PythonDateTimeFormatService.cs
+++ b/src/NetatmoProxy/NetatmoProxy.Services/PythonDateTimeFormatService.cs
@@ -1,4 +1,6 @@
-﻿namespace NetatmoProxy.Services
+﻿using Prometheus;
+
+namespace NetatmoProxy.Services
 {
     public class PythonDateTimeFormatService : IPythonDateTimeFormatService
     {
@@ -12,6 +14,7 @@
         public const string NetTimezoneWestEuropeStandardTime = "W. Europe Standard Time";
         public const string NetTimezoneEastEuropeStandardTime = "E. Europe Standard Time";
         public const string NetTimezoneCentralStandardTime = "Central Standard Time";
+        private static readonly Counter StrfTimeCalls = Metrics.CreateCounter($"{nameof(PythonDateTimeFormatService).ToLower()}_{nameof(StrfTime).ToLower()}calls_total", "Number of times StrfTime has been called.");
 
         private readonly INowService _nowService;
 
@@ -22,6 +25,7 @@
 
         public string StrfTime(string timezone, string format)
         {
+            StrfTimeCalls.Inc();
             var tzi = TimeZoneInfo.FindSystemTimeZoneById(NetTimeZoneInfoFromPythonTimeZone(timezone));
             var now = TimeZoneInfo.ConvertTimeFromUtc(_nowService.UtcNow, tzi);
             string strfTime = FormatPythonDayOfYear(now, format);

--- a/src/NetatmoProxy/NetatmoProxy/HealthCheck.cs
+++ b/src/NetatmoProxy/NetatmoProxy/HealthCheck.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace NetatmoProxy
+{
+    public sealed class HealthCheck : IHealthCheck
+    {
+        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(HealthCheckResult.Healthy());
+        }
+    }
+}

--- a/src/NetatmoProxy/NetatmoProxy/NetatmoProxy.csproj
+++ b/src/NetatmoProxy/NetatmoProxy/NetatmoProxy.csproj
@@ -12,8 +12,10 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="8.0.0" />
+    <PackageReference Include="prometheus-net.AspNetCore.HealthChecks" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes issue #31 
 - Netatmo proxy uses Prometheus exporter libraries to expose a /metrics endpoint
 - A systemd service polls the /api/Display endpoint at least every minute to populate the /metrics endpoint with data from Netatmo weather station
 - Prometheus polls the /metrics endpoint and Grafana provides a dashboard to view the data

![image](https://user-images.githubusercontent.com/791721/235920749-8198e5ab-3bca-432d-9621-6b7aedbe766e.png)
